### PR TITLE
Removed console.log call

### DIFF
--- a/src/js/angularOauth.js
+++ b/src/js/angularOauth.js
@@ -237,15 +237,11 @@
       var queryString = $location.path().replace(/[^\/]*\//, ''); // preceding slash omitted
       var params = parseKeyValue(queryString);
 
-
-      console.log('params', params);
       if (params.access_token) {
         localStorage.accessToken = params.access_token;
         localStorage.tokenExpires = params.expires_in;
         window.location.href = '/';
       }
-
-
     });
 
 })(window, document);


### PR DESCRIPTION
This console.log call prints in the browser's console all parameters received from the authentication API.
This is a bad practice and a potential security issue.

This PR removes the console.log call (identified on AGCO project)
